### PR TITLE
Allow domain overrides for challenge delegation

### DIFF
--- a/client.go
+++ b/client.go
@@ -84,7 +84,13 @@ func (p *Provider) doRequest(ctx context.Context, domain string, params map[stri
 	u, _ := url.Parse("https://www.duckdns.org/update")
 
 	// extract the main domain
-	mainDomain := getMainDomain(domain)
+	var mainDomain string
+	if p.OverrideDomain != "" {
+		mainDomain = p.OverrideDomain
+	} else {
+		mainDomain = getMainDomain(domain)
+	}
+	
 	if len(mainDomain) == 0 {
 		return nil, fmt.Errorf("unable to find the main domain for: %s", domain)
 	}

--- a/provider.go
+++ b/provider.go
@@ -9,7 +9,8 @@ import (
 
 // Provider implements the libdns interfaces for Duck DNS.
 type Provider struct {
-	APIToken string `json:"api_token,omitempty"`
+	APIToken       string `json:"api_token,omitempty"`
+	OverrideDomain string `json:"override_domain,omitempty"`
 
 	mutex sync.Mutex
 }


### PR DESCRIPTION
This enables delegation of a challenge for a domain (e.g.
my.example.com) to a DuckDNS subdomain (example.duckdns.org) as
described on the [LetsEncrypt website](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge). This is useful if your
"main" domain has a difficult DNS API or you'd rather just use
DuckDNS'. Example setup:

my.example.com -> CNAME example.duckdns.org
_acme-challenge.my.example.com -> CNAME example.duckdns.org

DNS challenges will be performed on example.duckdns.org, while the
actual certificate will be issued for my.example.com.

---

From LE:

> Since Let’s Encrypt follows the DNS standards when looking up TXT records for DNS-01 validation, you can use CNAME records or NS records to delegate answering the challenge to other DNS zones. This can be used to delegate the _acme-challenge subdomain to a validation-specific server or zone. It can also be used if your DNS provider is slow to update, and you want to delegate to a quicker-updating server.

I'm writing up an equivalent commit for caddy-dns/duckdns, too. I've gotten this working on my own home network pretty easily, and figured I'd share the change since it's (IMO) super useful and often much easier to delegate the DNS work to DuckDNS instead of messing with most other providers. At least for home networks, where DuckDNS is mostly used.

Without this change, the domain isn't overridden, and Caddy attempts to ask DuckDNS to update DNS entries for the "main" domain (in the example above, that's my.example.com). DuckDNS has no idea what to do with that, and returns an error.