### PR TITLE
Use AbsoluteName() from latest libdns

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ func (p *Provider) setRecord(ctx context.Context, zone string, record libdns.Rec
 
 	// sanitize the domain, combines the zone and record names
 	// the record name should typically be relative to the zone
-	domain := getDomainFromZoneAndRecord(zone, record)
+	domain := libdns.AbsoluteName(record.Name, zone)
 
 	params := map[string]string{"verbose": "true"}
 
@@ -90,7 +90,7 @@ func (p *Provider) doRequest(ctx context.Context, domain string, params map[stri
 	} else {
 		mainDomain = getMainDomain(domain)
 	}
-	
+
 	if len(mainDomain) == 0 {
 		return nil, fmt.Errorf("unable to find the main domain for: %s", domain)
 	}
@@ -132,18 +132,6 @@ func (p *Provider) doRequest(ctx context.Context, domain string, params map[stri
 	}
 
 	return bodyParts, nil
-}
-
-func getDomainFromZoneAndRecord(zone string, record libdns.Record) string {
-	// the record may contain the zone, and possibly the FQDN ".", so trim those
-	recordName := strings.TrimSuffix(strings.TrimRight(record.Name, "."), ".duckdns.org")
-
-	// concat the record to the zone
-	// note this may contain "_acme-challenge." as well, but
-	// that should be stripped off by getMainDomain() later
-	domain := recordName + "." + strings.TrimRight(zone, ".")
-
-	return domain
 }
 
 // DuckDNS only lets you write to your subdomain.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/libdns/duckdns
 go 1.14
 
 require (
-	github.com/libdns/libdns v0.0.0-20200430163404-ee2c42449104
-	github.com/miekg/dns v1.1.31
+	github.com/libdns/libdns v0.2.0
+	github.com/miekg/dns v1.1.40
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/libdns/libdns v0.0.0-20200430163404-ee2c42449104 h1:0/ke5mYkUWUVjIYvYwRBHIi2FultGNcMAGjBT3HZADo=
-github.com/libdns/libdns v0.0.0-20200430163404-ee2c42449104/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
-github.com/miekg/dns v1.1.31 h1:sJFOl9BgwbYAWOGEwr61FU28pqsBNdpRBnhGXtO06Oo=
-github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+github.com/libdns/libdns v0.2.0 h1:ewg3ByWrdUrxrje8ChPVMBNcotg7H9LQYg+u5De2RzI=
+github.com/libdns/libdns v0.2.0/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/miekg/dns v1.1.40 h1:pyyPFfGMnciYUk/mXpKkVmeMQjfXqt3FAJ2hy7tPiLA=
+github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
For https://github.com/libdns/libdns/issues/12, and for compat with https://github.com/mholt/caddy-dynamicdns/commit/aa9c8162558596bd1b32421838ffb842351b560b which uses `@` now, which wasn't handled by this lib's own implementation