### PR TITLE
Fix getMainDomain() to remove trailing dots

### DIFF
--- a/client.go
+++ b/client.go
@@ -139,6 +139,7 @@ func (p *Provider) doRequest(ctx context.Context, domain string, params map[stri
 // not in format subsubdomain.subdomain.duckdns.org.
 // So strip off everything that is not top 3 levels.
 func getMainDomain(domain string) string {
+	domain = strings.TrimSuffix(domain, ".")
 	split := dns.Split(domain)
 	if strings.HasSuffix(strings.ToLower(domain), "duckdns.org") {
 		if len(split) < 3 {


### PR DESCRIPTION
Explained in #4 
But, basically the new function `libdns.AbsoluteName()` retains the FQDN trailing dot,
but the prior method did not:  `getDomainFromZoneAndRecord(zone, record)`

The trailing period causes this function to break: getMainDomain(domain) called from inside doRequest()

This was found & tested with this simple test jig:
https://github.com/cameronelliott/libdns-issue


